### PR TITLE
UIEXPMGR-87 Missing permission, can't export "update authority headings" report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add EDIFACT orders export to job type filter in Export manager. Refs UIEXPMGR-62.
 * Sorting EDI export jobs by export method. Refs UIEXPMGR-81. 
 * Landing page displays export jobs before any filter is selected. Refs UIEXPMGR-82.
+* Missing permission, can't export "update authority headings" report. Refs UIEXPMGR-87.
 
 ## [2.4.3](https://github.com/folio-org/ui-export-manager/tree/v2.4.3) (2023-03-20)
 [Full Changelog](https://github.com/folio-org/ui-export-manager/compare/v2.4.2...v2.4.3)

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
         "description": "",
         "visible": true,
         "subPermissions": [
+          "data-export.job.item.post",
           "data-export.job.item.download",
           "data-export.job.item.resend"
         ]
@@ -61,7 +62,6 @@
           "data-export.config.item.get",
           "data-export.job.collection.get",
           "data-export.job.item.get",
-          "data-export.job.item.post",
           "data-export.edifact.orders.create",
           "tags.collection.get",
           "usergroups.collection.get",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
           "data-export.config.item.get",
           "data-export.job.collection.get",
           "data-export.job.item.get",
+          "data-export.job.item.post",
           "data-export.edifact.orders.create",
           "tags.collection.get",
           "usergroups.collection.get",


### PR DESCRIPTION
## Description
Added missing permission from `Export manager: All`

## Issues
[UIEXPMGR-87](https://issues.folio.org/browse/UIEXPMGR-87)