### PR TITLE
[UXPROD-3903] Support data-export-spring interface 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Refactor permissions to display link to download bulk-edit upload files. Refs UIEXPMGR-91.
 * Update Node.js to v18 in GitHub Actions. Refs UIEXPMGR-94.
 * *BREAKING* bump `react-intl` to `v6.4.4`. Refs UIEXPMGR-95.
+* Support `data-export-spring` interface `v2.0`. Refs UXPROD-3903.
 
 ## [2.4.3](https://github.com/folio-org/ui-export-manager/tree/v2.4.3) (2023-03-20)
 [Full Changelog](https://github.com/folio-org/ui-export-manager/compare/v2.4.2...v2.4.3)

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "route": "/export-manager",
     "okapiInterfaces": {
       "configuration": "2.0",
-      "data-export-spring": "1.0",
+      "data-export-spring": "1.0 2.0",
       "organizations.organizations": "1.0",
       "tags": "1.0",
       "users": "15.0 16.0"


### PR DESCRIPTION
# [Jira UXPROD-3903](https://folio-org.atlassian.net/browse/UXPROD-3903)

## Purpose
Work being done by @folio-org/bama in [mod-data-export-spring](https://github.com/folio-org/mod-data-export-spring/pull/270) and related modules necessitated a breaking change in the provided `data-export-spring` interface, bumping its version to `2.0`.  This breaking change has no impact on `ui-export-manager`; as such, we can safely update our `package.json` to support this new version.

> [!WARNING]
> This PR **must** be merged before https://github.com/folio-org/mod-data-export-spring/pull/270, otherwise the snapshot environment will break.