### PR TITLE
UIEXPMGR-102 Screen refreshes every time user clicks links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## (IN PROGRESS)
 
 * Export manager - Add accessibility testing to automated tests. Refs UIEXPMGR-101.
+* Screen refreshes every time user clicks links. Refs UIEXPMGR-102.
 
 ## [3.0.0](https://github.com/folio-org/ui-export-manager/tree/v3.0.0) (2023-10-12)
 [Full Changelog](https://github.com/folio-org/ui-export-manager/compare/v2.4.3...v3.0.0)

--- a/src/common/components/ExportJobId/ExportJobId.js
+++ b/src/common/components/ExportJobId/ExportJobId.js
@@ -40,7 +40,6 @@ export const ExportJobId = ({ job }) => {
 
           link.href = file;
           link.download = jobId;
-          link.target = '_blank';
 
           document.body.appendChild(link);
 


### PR DESCRIPTION
In this PR, the unnecessary target="_blank" was removed, which takes the user away from the page when downloading, thereby creating a refresh effect.  Refs [UIEXPMGR-102](https://folio-org.atlassian.net/browse/UIEXPMGR-102)