### PR TITLE
UIEXPMGR-108 React v19: refactor away from default props for functional components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Update HTML Page Title on Export Manager Tabs Page. Refs UIEXPMGR-105.
 * Update logic related to download files. Refs UIEXPMGR-106.
+* React v19: refactor away from default props for functional components. Refs UIEXPMGR-108.
 
 ## [3.1.0](https://github.com/folio-org/ui-export-manager/tree/v3.1.0) (2024-03-19)
 [Full Changelog](https://github.com/folio-org/ui-export-manager/compare/v3.0.0...v3.1.0)

--- a/src/ExportEdiJobs/ExportEdiJobsFilters/ExportEdiJobsFilters.js
+++ b/src/ExportEdiJobs/ExportEdiJobsFilters/ExportEdiJobsFilters.js
@@ -21,9 +21,9 @@ import { ExportMethodFilter } from './ExportMethodFilter';
 const applyFiltersAdapter = (applyFilters) => ({ name, values }) => applyFilters(name, values);
 
 export const ExportEdiJobsFilters = ({
-  activeFilters,
-  applyFilters,
-  disabled,
+    disabled = false,
+    activeFilters,
+    applyFilters,
 }) => {
   const adaptedApplyFilters = useCallback(
     applyFiltersAdapter(applyFilters),
@@ -103,8 +103,4 @@ ExportEdiJobsFilters.propTypes = {
   activeFilters: PropTypes.object.isRequired,
   applyFilters: PropTypes.func.isRequired,
   disabled: PropTypes.bool,
-};
-
-ExportEdiJobsFilters.defaultProps = {
-  disabled: false,
 };

--- a/src/ExportJobs/ExportJobsFilters/ExportJobsFilters.js
+++ b/src/ExportJobs/ExportJobsFilters/ExportJobsFilters.js
@@ -49,9 +49,9 @@ const typeFilterOptions = EXPORT_JOB_TYPES.map(type => ({
 }));
 
 export const ExportJobsFilters = ({
-  activeFilters,
-  applyFilters,
-  disabled,
+    disabled = false,
+    activeFilters,
+    applyFilters,
 }) => {
   const adaptedApplyFilters = useCallback(
     applyFiltersAdapter(applyFilters),
@@ -119,8 +119,4 @@ ExportJobsFilters.propTypes = {
   activeFilters: PropTypes.object.isRequired,
   applyFilters: PropTypes.func.isRequired,
   disabled: PropTypes.bool,
-};
-
-ExportJobsFilters.defaultProps = {
-  disabled: false,
 };


### PR DESCRIPTION
After this PR merged all default props for functional components will be repalced with new syntax. Refs [UIDEXP-376](https://folio-org.atlassian.net/browse/UIDEXP-376)