### PR TITLE
UIEXPMGR-110 Add default sorting by job id

### DIFF
--- a/src/ExportEdiJobs/ExportEdiJobsList/ExportEdiJobsList.js
+++ b/src/ExportEdiJobs/ExportEdiJobsList/ExportEdiJobsList.js
@@ -66,7 +66,7 @@ export const ExportEdiJobsList = ({
 }) => {
   const history = useHistory();
   const location = useLocation();
-  const DEFAULT_SORTING = { [SORTING_PARAMETER]: 'endTime', [SORTING_DIRECTION_PARAMETER]: DESC_DIRECTION };
+  const DEFAULT_SORTING = { [SORTING_PARAMETER]: 'jobId', [SORTING_DIRECTION_PARAMETER]: DESC_DIRECTION };
 
   const [
     sortingField,

--- a/src/ExportJobs/ExportJobsList/ExportJobsList.js
+++ b/src/ExportJobs/ExportJobsList/ExportJobsList.js
@@ -62,7 +62,7 @@ export const ExportJobsList = ({
 }) => {
   const history = useHistory();
   const location = useLocation();
-  const DEFAULT_SORTING = { [SORTING_PARAMETER]: 'endTime', [SORTING_DIRECTION_PARAMETER]: DESC_DIRECTION };
+  const DEFAULT_SORTING = { [SORTING_PARAMETER]: 'jobId', [SORTING_DIRECTION_PARAMETER]: DESC_DIRECTION };
 
   const [
     sortingField,


### PR DESCRIPTION
In scope of https://github.com/folio-org/ui-export-manager/pull/191 default sorting was missed.

![image](https://github.com/user-attachments/assets/36d9b4ce-f747-442f-8e24-4ded59bcfd0a)
