### PR TITLE
UIEXPMGR-122 Clear form when filters unselected

### DIFF
--- a/src/ExportEdiJobs/ExportEdiJobs.js
+++ b/src/ExportEdiJobs/ExportEdiJobs.js
@@ -49,7 +49,7 @@ export const ExportEdiJobs = () => {
 
   const { pagination, changePage } = usePagination({ limit: RESULT_COUNT_INCREMENT, offset: 0 });
   const {
-    isLoading,
+    isFetching,
     exportEdiJobs,
     totalCount,
     refetch,
@@ -96,7 +96,7 @@ export const ExportEdiJobs = () => {
         >
           {(({ height, width }) => (
             <ExportEdiJobsList
-              isLoading={isLoading}
+              isLoading={isFetching}
               onNeedMoreData={changePage}
               exportJobs={exportEdiJobs}
               totalCount={totalCount}

--- a/src/ExportJobs/ExportJobs.js
+++ b/src/ExportJobs/ExportJobs.js
@@ -53,6 +53,7 @@ export const ExportJobs = () => {
   const { pagination, changePage } = usePagination({ limit: RESULT_COUNT_INCREMENT, offset: 0 });
   const {
     isLoading,
+    isFetching,
     exportJobs,
     totalCount,
   } = useExportJobsQuery(location.search, pagination, filters);
@@ -66,12 +67,10 @@ export const ExportJobs = () => {
             toggleFilters={toggleFilters}
           >
             <Navigation />
-
             <SingleSearchForm
               applySearch={applySearch}
               changeSearch={changeSearch}
               searchQuery={searchQuery}
-              isLoading={isLoading}
               ariaLabelId="ui-export-manager.exportJobs.search"
             />
 
@@ -80,7 +79,6 @@ export const ExportJobs = () => {
               reset={resetFilters}
               disabled={!location.search || isLoading}
             />
-
             <ExportJobsFilters
               activeFilters={filters}
               applyFilters={applyFilters}
@@ -88,7 +86,6 @@ export const ExportJobs = () => {
           </FiltersPane>
         )
       }
-
         <ResultsPane
           title={formatMessage({ id: 'ui-export-manager.exportJobs' })}
           count={totalCount}
@@ -99,7 +96,7 @@ export const ExportJobs = () => {
         >
           {(({ height, width }) => (
             <ExportJobsList
-              isLoading={isLoading}
+              isLoading={isFetching}
               onNeedMoreData={changePage}
               exportJobs={exportJobs}
               totalCount={totalCount}

--- a/src/common/helpers.js
+++ b/src/common/helpers.js
@@ -1,0 +1,9 @@
+export const getDataByFiltersState = (data, filters) => {
+  const hasAppliedFilters = Object.values(filters).filter(Boolean).length > 0;
+
+  if (!hasAppliedFilters) {
+    return undefined;
+  }
+
+  return data;
+};


### PR DESCRIPTION
In scope of https://github.com/folio-org/ui-export-manager/pull/216 one bug was found. With `keepPrevousState: true` after unselect last filter, data is still visible on the screen. 
