### PR TITLE
UIEXPMGR-129 Align final form versions with stripes

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,11 +152,13 @@
   },
   "dependencies": {
     "@folio/stripes-acq-components": "^7.0.0",
+    "final-form": "^4.0.0",
+    "final-form-arrays": "^3.0.0",
     "lodash": "^4.17.21",
     "prop-types": "^15.5.10",
     "query-string": "^6.1.0",
-    "react-final-form": "^7.0.0",
-    "react-final-form-arrays": "^4.0.0",
+    "react-final-form": "^6.0.0",
+    "react-final-form-arrays": "^3.0.0",
     "react-router-prop-types": "^1.0.4"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Purpose
https://folio-org.atlassian.net/browse/UIEXPMGR-129

Base PR - #235 

Although the release notes for `final-form` ([https://github.com/final-form/react-final-form/releases/tag/v7.0.0](https://github.com/final-form/react-final-form/releases/tag/v7.0.0)) state that there are no breaking changes, using it causes issues when combined with `stripes-final-form`, resulting in the error "useFieldArray must be used inside of a `<Form>` component" in this case.
